### PR TITLE
GAME-105 - O Escolhido desconsidera jogadores que caíram durante a votação

### DIFF
--- a/src/realtime/games/OEscolhido/OEscolhido.ts
+++ b/src/realtime/games/OEscolhido/OEscolhido.ts
@@ -20,7 +20,8 @@ class OEscolhido extends Game {
   playerGameData: player[];
   session: votingSession[];
   mostVotedPlayers: mostVoted[];
-  noPlayer: player = {          //quem cair durante o jogo vai votar no noPlayer
+  noPlayer: player = {
+    //quem cair durante o jogo vai votar no noPlayer
     playerID: -1,
     roomCode: 'none',
     currentlyPlaying: true,
@@ -29,7 +30,7 @@ class OEscolhido extends Game {
     beers: 0,
     socketID: 'none',
     currentTurn: false,
-  }
+  };
 
   constructor(io: Server, room: string) {
     super(io, room);
@@ -85,7 +86,7 @@ class OEscolhido extends Game {
       }
     });
 
-    this.checkVotingStatus();   //verifica se já pode finalizar a votação - e o faz em caso afirmativo
+    this.checkVotingStatus(); //verifica se já pode finalizar a votação - e o faz em caso afirmativo
   }
 
   beginVoting() {
@@ -152,24 +153,35 @@ class OEscolhido extends Game {
   }
 
   handleDisconnect(id: string): void {
-    const disconnectedPlayers = this.runtimeStorage.rooms.get(this.roomCode)?.disconnectedPlayers;
-    const disconnectedPlayerName = disconnectedPlayers?.find(p => p.socketID === id)?.nickname;
+    const disconnectedPlayers = this.runtimeStorage.rooms.get(
+      this.roomCode
+    )?.disconnectedPlayers;
+    const disconnectedPlayerName = disconnectedPlayers?.find(
+      (p) => p.socketID === id
+    )?.nickname;
 
-    if(disconnectedPlayerName){
-      const i = this.session.findIndex(player => player.nickname === disconnectedPlayerName);
-      console.log('O jogador ' + this.session[i].nickname + 'desconectou-se e não pode mais votar.');
+    if (disconnectedPlayerName) {
+      const i = this.session.findIndex(
+        (player) => player.nickname === disconnectedPlayerName
+      );
+      console.log(
+        'O jogador ' +
+          this.session[i].nickname +
+          'desconectou-se e não pode mais votar.'
+      );
 
-      if(this.session[i].hasVotedIn === undefined){
+      if (this.session[i].hasVotedIn === undefined) {
         this.session[i].hasVotedIn = this.noPlayer;
       }
-      
+
       this.checkVotingStatus();
     }
   }
 
-  checkVotingStatus():void {      //finaliza a votação caso todos os jogadores disponíveis já tiverem votado
+  checkVotingStatus(): void {
+    //finaliza a votação caso todos os jogadores disponíveis já tiverem votado
     if (this.session.find((player) => player.hasVotedIn === undefined)) {
-      return; 
+      return;
     } else {
       this.finishVoting(); //se todos já votaram, prosseguimos com os resultados
     }


### PR DESCRIPTION
Neste PR:

> Jogadores que caíram no meio da votação ainda podem receber votos, e caso já tenham votado têm estes dados mantidos, mas não são mais contabilizados entre quem falta para votar. Portanto, se todo mundo que falta votar tiver caído de uma vez, a votação encerra antes do tempo limite de 10 segundos encerrar.

Bugs conhecidos:

> Nenhum.